### PR TITLE
Correct link in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-Conversation-AI is an initiative to protect voices in conversation. We develop machine learning models to classify the impact of comments on conversations, and we serve these to platforms via the Perspective API. We also conduct experiments and publish original research to explore the strengths and weaknesses of ML as a tool for combating online toxicity and harassment. Further details can be found in our [research resources page](https://perspectiveapi.com/research/), and our [blog] (https://medium.com/jigsaw/toxicity/home).
+Conversation-AI is an initiative to protect voices in conversation. We develop machine learning models to classify the impact of comments on conversations, and we serve these to platforms via the Perspective API. We also conduct experiments and publish original research to explore the strengths and weaknesses of ML as a tool for combating online toxicity and harassment. Further details can be found in our [research resources page](https://perspectiveapi.com/research/), and our [blog](https://medium.com/jigsaw/toxicity/home).
 
 # Vision
 


### PR DESCRIPTION
Correct blog link, which is currently rendering incorrectly on https://conversationai.github.io/:

<img width="520" alt="Screen Shot 2021-03-09 at 4 43 13 PM" src="https://user-images.githubusercontent.com/3759507/110542058-98468280-80f6-11eb-8948-2d6f0e95b582.png">
